### PR TITLE
Urgent fixes for failing requests

### DIFF
--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -27,7 +27,7 @@ public class HtmlController {
   @Autowired private ConfigurationService configurationService;
 
   // catches text/html requests for all endpoints and gives an optional redirect link
-  @GetMapping(
+  /*@GetMapping(
       value = {
         "/linked-data",
         "/linked-data/{featureSource}",
@@ -60,7 +60,7 @@ public class HtmlController {
       @RequestParam(required = false) Map<String, String> params)
       throws Exception {
     return processHtml(request, response);
-  }
+  }*/
 
   private String removeHtmlFormatFromQueryString(String oldQueryString) {
     // remove it if user put it somewhere in the middle

--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -2,19 +2,14 @@ package gov.usgs.owi.nldi.controllers;
 
 import gov.usgs.owi.nldi.services.ConfigurationService;
 import gov.usgs.owi.nldi.services.LogService;
-import io.swagger.v3.oas.annotations.Hidden;
 import java.math.BigInteger;
-import java.util.Map;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
-import org.springframework.http.MediaType;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
-import org.springframework.web.bind.annotation.GetMapping;
-import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 

--- a/src/main/java/gov/usgs/owi/nldi/converters/FeatureListMessageConverter.java
+++ b/src/main/java/gov/usgs/owi/nldi/converters/FeatureListMessageConverter.java
@@ -2,7 +2,6 @@ package gov.usgs.owi.nldi.converters;
 
 import com.fasterxml.jackson.core.JsonFactoryBuilder;
 import com.fasterxml.jackson.core.JsonGenerator;
-import com.fasterxml.jackson.core.JsonParser;
 import gov.usgs.owi.nldi.controllers.BaseController;
 import gov.usgs.owi.nldi.model.Feature;
 import gov.usgs.owi.nldi.model.FeatureList;

--- a/src/test/java/gov/usgs/owi/nldi/controllers/HtmlControllerIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/HtmlControllerIT.java
@@ -3,6 +3,7 @@ package gov.usgs.owi.nldi.controllers;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
+import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;
@@ -14,6 +15,7 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @EnableWebMvc
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
+@Disabled
 public class HtmlControllerIT extends BaseControllerIT {
 
   @LocalServerPort private int port;


### PR DESCRIPTION
This is a patch for requests that are failing for tools using the NLDI. The HTML page mapping is causing issues where certain requests will return the HTML page rather than the default content type. As a patch while this is investigated, the HTML mappings have been disabled. The only side effect of this is that browsers will return the JSON instead of an HTML page with redirect links.

The second issue is with empty navigation responses returning invalid GeoJSON. I have added some additional logic to insert an empty "features" array when this is the case.