### PR TITLE
Created custom request filter to handle multiple `Accept` header values

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,7 +4,21 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
-## [Unreleased](https://github.com/internetofwater/nldi-services/compare/nldi-services-1.11.0...master)
+## [Unreleased](https://github.com/internetofwater/nldi-services/compare/1.12.1...master)
+### Changed
+* Re-enabled HTML pages
+
+### Fixed
+* Added a custom filter to handle `Accept` headers with multiple values prioritizing html
+
+## [1.12.1](https://github.com/internetofwater/nldi-services/compare/1.12.0...1.12.1)
+### Fixed
+* Empty navigations now return valid GeoJSON
+
+### Changed
+* Temporarily disabled HTML pages during issue investigation
+
+## [1.12.0](https://github.com/internetofwater/nldi-services/compare/nldi-services-1.11.0...1.12.0)
 ### Changed
 * Upgraded spring boot starter version
 * Enabled content negotiation for all endpoints

--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -3,13 +3,19 @@ package gov.usgs.owi.nldi.controllers;
 import gov.usgs.owi.nldi.services.ConfigurationService;
 import gov.usgs.owi.nldi.services.LogService;
 import java.math.BigInteger;
+import java.util.Map;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
+
+import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
+import org.springframework.http.MediaType;
 import org.springframework.util.FileCopyUtils;
 import org.springframework.util.StringUtils;
+import org.springframework.web.bind.annotation.GetMapping;
+import org.springframework.web.bind.annotation.RequestParam;
 import org.springframework.web.bind.annotation.RestController;
 import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
@@ -22,7 +28,7 @@ public class HtmlController {
   @Autowired private ConfigurationService configurationService;
 
   // catches text/html requests for all endpoints and gives an optional redirect link
-  /*@GetMapping(
+  @GetMapping(
       value = {
         "/linked-data",
         "/linked-data/{featureSource}",
@@ -49,13 +55,13 @@ public class HtmlController {
       produces = MediaType.TEXT_HTML_VALUE)
   @Hidden
   public String getHtmlRedirect(
-      HttpServletRequest request,
-      HttpServletResponse response,
-      // catch all params
-      @RequestParam(required = false) Map<String, String> params)
+          HttpServletRequest request,
+          HttpServletResponse response,
+          // catch all params
+          @RequestParam(required = false) Map<String, String> params)
       throws Exception {
     return processHtml(request, response);
-  }*/
+  }
 
   private String removeHtmlFormatFromQueryString(String oldQueryString) {
     // remove it if user put it somewhere in the middle

--- a/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
+++ b/src/main/java/gov/usgs/owi/nldi/controllers/HtmlController.java
@@ -2,13 +2,12 @@ package gov.usgs.owi.nldi.controllers;
 
 import gov.usgs.owi.nldi.services.ConfigurationService;
 import gov.usgs.owi.nldi.services.LogService;
+import io.swagger.v3.oas.annotations.Hidden;
 import java.math.BigInteger;
 import java.util.Map;
 import java.util.Objects;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-
-import io.swagger.v3.oas.annotations.Hidden;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.core.io.ClassPathResource;
 import org.springframework.http.MediaType;
@@ -55,10 +54,10 @@ public class HtmlController {
       produces = MediaType.TEXT_HTML_VALUE)
   @Hidden
   public String getHtmlRedirect(
-          HttpServletRequest request,
-          HttpServletResponse response,
-          // catch all params
-          @RequestParam(required = false) Map<String, String> params)
+      HttpServletRequest request,
+      HttpServletResponse response,
+      // catch all params
+      @RequestParam(required = false) Map<String, String> params)
       throws Exception {
     return processHtml(request, response);
   }

--- a/src/main/java/gov/usgs/owi/nldi/springinit/MutableHttpServletRequest.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/MutableHttpServletRequest.java
@@ -1,0 +1,53 @@
+package gov.usgs.owi.nldi.springinit;
+
+import javax.servlet.http.HttpServletRequest;
+import javax.servlet.http.HttpServletRequestWrapper;
+import java.util.*;
+
+final class MutableHttpServletRequest extends HttpServletRequestWrapper {
+
+    private final Map<String, String> customHeaders;
+
+    public MutableHttpServletRequest(HttpServletRequest request) {
+        super(request);
+        this.customHeaders = new HashMap<>();
+    }
+
+    public void putHeader(String name, String value) {
+        this.customHeaders.put(name, value);
+    }
+
+    public String getHeader(String name) {
+        String headerValue = customHeaders.get(name);
+
+        if (headerValue != null) {
+            return headerValue;
+        }
+
+        return ((HttpServletRequest) getRequest()).getHeader(name);
+    }
+
+    public Enumeration<String> getHeaderNames() {
+        // create a set of the custom header names
+        Set<String> set = new HashSet<>(customHeaders.keySet());
+
+        // now add the headers from the wrapped request object
+        Enumeration<String> e = ((HttpServletRequest) getRequest()).getHeaderNames();
+        while (e.hasMoreElements()) {
+            // add the names of the request headers into the list
+            String n = e.nextElement();
+            set.add(n);
+        }
+
+        // create an enumeration from the set and return
+        return Collections.enumeration(set);
+    }
+
+    @Override
+    public Enumeration<String> getHeaders(String name) {
+        Set<String> headerValues = new HashSet<>();
+        headerValues.add(this.customHeaders.get(name));
+
+        return Collections.enumeration(headerValues);
+    }
+}

--- a/src/main/java/gov/usgs/owi/nldi/springinit/MutableHttpServletRequest.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/MutableHttpServletRequest.java
@@ -1,53 +1,53 @@
 package gov.usgs.owi.nldi.springinit;
 
+import java.util.*;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletRequestWrapper;
-import java.util.*;
 
 final class MutableHttpServletRequest extends HttpServletRequestWrapper {
 
-    private final Map<String, String> customHeaders;
+  private final Map<String, String> customHeaders;
 
-    public MutableHttpServletRequest(HttpServletRequest request) {
-        super(request);
-        this.customHeaders = new HashMap<>();
+  public MutableHttpServletRequest(HttpServletRequest request) {
+    super(request);
+    this.customHeaders = new HashMap<>();
+  }
+
+  public void putHeader(String name, String value) {
+    this.customHeaders.put(name, value);
+  }
+
+  public String getHeader(String name) {
+    String headerValue = customHeaders.get(name);
+
+    if (headerValue != null) {
+      return headerValue;
     }
 
-    public void putHeader(String name, String value) {
-        this.customHeaders.put(name, value);
+    return ((HttpServletRequest) getRequest()).getHeader(name);
+  }
+
+  public Enumeration<String> getHeaderNames() {
+    // create a set of the custom header names
+    Set<String> set = new HashSet<>(customHeaders.keySet());
+
+    // now add the headers from the wrapped request object
+    Enumeration<String> e = ((HttpServletRequest) getRequest()).getHeaderNames();
+    while (e.hasMoreElements()) {
+      // add the names of the request headers into the list
+      String n = e.nextElement();
+      set.add(n);
     }
 
-    public String getHeader(String name) {
-        String headerValue = customHeaders.get(name);
+    // create an enumeration from the set and return
+    return Collections.enumeration(set);
+  }
 
-        if (headerValue != null) {
-            return headerValue;
-        }
+  @Override
+  public Enumeration<String> getHeaders(String name) {
+    Set<String> headerValues = new HashSet<>();
+    headerValues.add(this.customHeaders.get(name));
 
-        return ((HttpServletRequest) getRequest()).getHeader(name);
-    }
-
-    public Enumeration<String> getHeaderNames() {
-        // create a set of the custom header names
-        Set<String> set = new HashSet<>(customHeaders.keySet());
-
-        // now add the headers from the wrapped request object
-        Enumeration<String> e = ((HttpServletRequest) getRequest()).getHeaderNames();
-        while (e.hasMoreElements()) {
-            // add the names of the request headers into the list
-            String n = e.nextElement();
-            set.add(n);
-        }
-
-        // create an enumeration from the set and return
-        return Collections.enumeration(set);
-    }
-
-    @Override
-    public Enumeration<String> getHeaders(String name) {
-        Set<String> headerValues = new HashSet<>();
-        headerValues.add(this.customHeaders.get(name));
-
-        return Collections.enumeration(headerValues);
-    }
+    return Collections.enumeration(headerValues);
+  }
 }

--- a/src/main/java/gov/usgs/owi/nldi/springinit/TransactionFilter.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/TransactionFilter.java
@@ -1,56 +1,60 @@
 package gov.usgs.owi.nldi.springinit;
 
 import gov.usgs.owi.nldi.controllers.BaseController;
-import org.springframework.http.MediaType;
-import org.springframework.stereotype.Component;
-
-import javax.servlet.*;
-import javax.servlet.http.HttpServletRequest;
 import java.io.IOException;
 import java.util.ArrayList;
 import java.util.Collections;
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
 
 @Component
 public class TransactionFilter implements Filter {
-    @Override
-    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
-        HttpServletRequest httpRequest = (HttpServletRequest)servletRequest;
+  @Override
+  public void doFilter(
+      ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain)
+      throws IOException, ServletException {
+    HttpServletRequest httpRequest = (HttpServletRequest) servletRequest;
 
-        if (httpRequest.getHeader("Accept") == null) {
-            filterChain.doFilter(servletRequest, servletResponse);
-            return;
-        }
-
-        String[] requestHeaders = httpRequest.getHeader("Accept").split("\\s*,\\s*");
-        ArrayList<String> headerList = new ArrayList<>();
-        Collections.addAll(headerList, requestHeaders);
-
-        // customize enforcement of Accept header order
-        // this helps decide when to display html pages
-        if (headerList.contains(MediaType.TEXT_HTML_VALUE)) {
-            if (headerList.contains(MediaType.APPLICATION_JSON_VALUE)
-                    && headerList.indexOf(MediaType.APPLICATION_JSON_VALUE) > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
-                headerList.remove(MediaType.APPLICATION_JSON_VALUE);
-                headerList.remove(MediaType.ALL_VALUE);
-            } else if (headerList.contains(BaseController.MIME_TYPE_GEOJSON)
-                    && headerList.indexOf(BaseController.MIME_TYPE_GEOJSON) > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
-                headerList.remove(BaseController.MIME_TYPE_GEOJSON);
-                headerList.remove(MediaType.ALL_VALUE);
-            } else if (headerList.contains(BaseController.MIME_TYPE_JSONLD)
-                    && headerList.indexOf(BaseController.MIME_TYPE_JSONLD) > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
-                headerList.remove(BaseController.MIME_TYPE_JSONLD);
-                headerList.remove(MediaType.ALL_VALUE);
-            } else if (headerList.contains(MediaType.APPLICATION_JSON_VALUE)
-                    || headerList.contains(BaseController.MIME_TYPE_GEOJSON)
-                    || headerList.contains(BaseController.MIME_TYPE_JSONLD)) {
-                headerList.remove(MediaType.TEXT_HTML_VALUE);
-                headerList.remove(MediaType.ALL_VALUE);
-            }
-        }
-
-        MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
-        mutableRequest.putHeader("Accept", String.join(",", headerList));
-
-        filterChain.doFilter(mutableRequest, servletResponse);
+    if (httpRequest.getHeader("Accept") == null) {
+      filterChain.doFilter(servletRequest, servletResponse);
+      return;
     }
+
+    String[] requestHeaders = httpRequest.getHeader("Accept").split("\\s*,\\s*");
+    ArrayList<String> headerList = new ArrayList<>();
+    Collections.addAll(headerList, requestHeaders);
+
+    // customize enforcement of Accept header order
+    // this helps decide when to display html pages
+    if (headerList.contains(MediaType.TEXT_HTML_VALUE)) {
+      if (headerList.contains(MediaType.APPLICATION_JSON_VALUE)
+          && headerList.indexOf(MediaType.APPLICATION_JSON_VALUE)
+              > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
+        headerList.remove(MediaType.APPLICATION_JSON_VALUE);
+        headerList.remove(MediaType.ALL_VALUE);
+      } else if (headerList.contains(BaseController.MIME_TYPE_GEOJSON)
+          && headerList.indexOf(BaseController.MIME_TYPE_GEOJSON)
+              > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
+        headerList.remove(BaseController.MIME_TYPE_GEOJSON);
+        headerList.remove(MediaType.ALL_VALUE);
+      } else if (headerList.contains(BaseController.MIME_TYPE_JSONLD)
+          && headerList.indexOf(BaseController.MIME_TYPE_JSONLD)
+              > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
+        headerList.remove(BaseController.MIME_TYPE_JSONLD);
+        headerList.remove(MediaType.ALL_VALUE);
+      } else if (headerList.contains(MediaType.APPLICATION_JSON_VALUE)
+          || headerList.contains(BaseController.MIME_TYPE_GEOJSON)
+          || headerList.contains(BaseController.MIME_TYPE_JSONLD)) {
+        headerList.remove(MediaType.TEXT_HTML_VALUE);
+        headerList.remove(MediaType.ALL_VALUE);
+      }
+    }
+
+    MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
+    mutableRequest.putHeader("Accept", String.join(",", headerList));
+
+    filterChain.doFilter(mutableRequest, servletResponse);
+  }
 }

--- a/src/main/java/gov/usgs/owi/nldi/springinit/TransactionFilter.java
+++ b/src/main/java/gov/usgs/owi/nldi/springinit/TransactionFilter.java
@@ -1,0 +1,56 @@
+package gov.usgs.owi.nldi.springinit;
+
+import gov.usgs.owi.nldi.controllers.BaseController;
+import org.springframework.http.MediaType;
+import org.springframework.stereotype.Component;
+
+import javax.servlet.*;
+import javax.servlet.http.HttpServletRequest;
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+
+@Component
+public class TransactionFilter implements Filter {
+    @Override
+    public void doFilter(ServletRequest servletRequest, ServletResponse servletResponse, FilterChain filterChain) throws IOException, ServletException {
+        HttpServletRequest httpRequest = (HttpServletRequest)servletRequest;
+
+        if (httpRequest.getHeader("Accept") == null) {
+            filterChain.doFilter(servletRequest, servletResponse);
+            return;
+        }
+
+        String[] requestHeaders = httpRequest.getHeader("Accept").split("\\s*,\\s*");
+        ArrayList<String> headerList = new ArrayList<>();
+        Collections.addAll(headerList, requestHeaders);
+
+        // customize enforcement of Accept header order
+        // this helps decide when to display html pages
+        if (headerList.contains(MediaType.TEXT_HTML_VALUE)) {
+            if (headerList.contains(MediaType.APPLICATION_JSON_VALUE)
+                    && headerList.indexOf(MediaType.APPLICATION_JSON_VALUE) > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
+                headerList.remove(MediaType.APPLICATION_JSON_VALUE);
+                headerList.remove(MediaType.ALL_VALUE);
+            } else if (headerList.contains(BaseController.MIME_TYPE_GEOJSON)
+                    && headerList.indexOf(BaseController.MIME_TYPE_GEOJSON) > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
+                headerList.remove(BaseController.MIME_TYPE_GEOJSON);
+                headerList.remove(MediaType.ALL_VALUE);
+            } else if (headerList.contains(BaseController.MIME_TYPE_JSONLD)
+                    && headerList.indexOf(BaseController.MIME_TYPE_JSONLD) > headerList.indexOf(MediaType.TEXT_HTML_VALUE)) {
+                headerList.remove(BaseController.MIME_TYPE_JSONLD);
+                headerList.remove(MediaType.ALL_VALUE);
+            } else if (headerList.contains(MediaType.APPLICATION_JSON_VALUE)
+                    || headerList.contains(BaseController.MIME_TYPE_GEOJSON)
+                    || headerList.contains(BaseController.MIME_TYPE_JSONLD)) {
+                headerList.remove(MediaType.TEXT_HTML_VALUE);
+                headerList.remove(MediaType.ALL_VALUE);
+            }
+        }
+
+        MutableHttpServletRequest mutableRequest = new MutableHttpServletRequest(httpRequest);
+        mutableRequest.putHeader("Accept", String.join(",", headerList));
+
+        filterChain.doFilter(mutableRequest, servletResponse);
+    }
+}

--- a/src/test/java/gov/usgs/owi/nldi/controllers/HtmlControllerIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/HtmlControllerIT.java
@@ -15,7 +15,6 @@ import org.springframework.web.servlet.config.annotation.EnableWebMvc;
 
 @EnableWebMvc
 @SpringBootTest(webEnvironment = WebEnvironment.RANDOM_PORT)
-@Disabled
 public class HtmlControllerIT extends BaseControllerIT {
 
   @LocalServerPort private int port;

--- a/src/test/java/gov/usgs/owi/nldi/controllers/HtmlControllerIT.java
+++ b/src/test/java/gov/usgs/owi/nldi/controllers/HtmlControllerIT.java
@@ -3,7 +3,6 @@ package gov.usgs.owi.nldi.controllers;
 import static org.junit.jupiter.api.Assertions.assertTrue;
 
 import org.junit.jupiter.api.BeforeEach;
-import org.junit.jupiter.api.Disabled;
 import org.junit.jupiter.api.Test;
 import org.springframework.beans.factory.annotation.Autowired;
 import org.springframework.boot.test.context.SpringBootTest;


### PR DESCRIPTION
Before making a pull request
----------------------------

- [x] Make pull request title clear and descriptive
- [x] Link(s) to issue describing bug fixed or need for change
- [x] Make sure all tests run
- [x] Update the changelog appropriately

Description
---------------------------
This fixes an issue where HTML pages were being prioritized over other media types when specified together in the `Accept` header. The filter acts as a patch and removes either the HTML value, or the JSON, GeoJSON, etc, depending on the order it is specified. (First occurrence takes priority) It is not a perfect solution, but allows us to still meet the legacy expectation for HTML pages.

Closes #317 

After making a pull request
---------------------------
- [x] If appropriate, put the link to the PR in the JIRA ticket
- [x] Assign someone to review unless the change is trivial
