### PR TITLE
change pipeline version being used from 2022-05-23-r1 to 2024-04-04-r0

### DIFF
--- a/.gitlab-ci.yml
+++ b/.gitlab-ci.yml
@@ -1,5 +1,5 @@
 include:
   - project: "wma/nhgf/nldi/mirror-pipelines"
-    ref: "2022-05-23-r1"
+    ref: "2024-04-04-r0"
     file:
       - "nldi-services.yml"


### PR DESCRIPTION
Changes the pipeline being used from 2022-05-23-r1 to 2024-04-04-r0

This is in an effort to facilitate the deployment of python, java, and a mixed-bag set of images to ECR depending on what branch the pipeline is being triggered on.